### PR TITLE
Limit size of partials by chunk size

### DIFF
--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -1,4 +1,3 @@
-using SparseArrays
 struct ForwardColorJacCache{T,T2,T3,T4,T5}
     t::T
     fx::T2
@@ -123,27 +122,5 @@ function forwarddiff_color_jacobian!(J::AbstractMatrix{<:Number},
         end
 
     end
-
     nothing
-    #=
-    t .= Dual{typeof(f)}.(x, p)
-    f(fx, t)
-
-    if J isa SparseMatrixCSC
-        rows_index, cols_index, val = findnz(J)
-        for color_i in 1:maximum(color)
-            dx .= partials.(fx,color_i)
-            for i in 1:length(cols_index)
-                if color[cols_index[i]]==color_i
-                    J[rows_index[i],cols_index[i]] = dx[rows_index[i]]
-                end
-            end
-        end
-    else # Compute the compressed version
-        for color_i in 1:maximum(color)
-            J[:,i] .= partials.(fx,color_i)
-        end
-    end
-    nothing
-    =#
 end

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -55,11 +55,7 @@ function generate_chunked_partials(x,color,::Val{N}) where N
 
     for color_i in 1:maximum(color)
         for j in 1:length(x)
-            if color[j]==color_i
-                partials[j,color_i] = true
-            else
-                partials[j,color_i] = false
-            end
+            partials[j, color_i] = color[j] == color_i
         end
     end
 

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -128,6 +128,7 @@ function forwarddiff_color_jacobian!(J::AbstractMatrix{<:Number},
                     color_i = 1
                 end
             end
+        end
     end
     nothing
 end

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -119,8 +119,15 @@ function forwarddiff_color_jacobian!(J::AbstractMatrix{<:Number},
                     color_i = 1
                 end
             end
-        end
-
+        else
+            for j in 1:chunksize
+                col_index = (i-1)*chunksize + j
+                J[:, col_index] .= partials(fx, color_i)
+                color_i += 1
+                if color_i == maximum(color) + 1
+                    color_i = 1
+                end
+            end
     end
     nothing
 end

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -118,7 +118,7 @@ function forwarddiff_color_jacobian!(J::AbstractMatrix{<:Number},
         else
             for j in 1:chunksize
                 col_index = (i-1)*chunksize + j
-                J[:, col_index] .= partials(fx, color_i)
+                J[:, col_index] .= partials.(fx, color_i)
                 color_i += 1
                 if color_i == maximum(color) + 1
                     color_i = 1

--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -111,9 +111,6 @@ function forwarddiff_color_jacobian!(J::AbstractMatrix{<:Number},
                     end
                 end
                 color_i += 1
-                if color_i == maximum(color) + 1
-                    color_i = 1
-                end
             end
         else
             for j in 1:chunksize


### PR DESCRIPTION
Allows user to control the number of partials to be computed simultaneously by the program by passing the limit as chunk size.

Reference: #23