### PR TITLE
Remove dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 VertexSafeGraphs = "19fa3120-7c27-5ec5-8db8-b0b0aa330d6f"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 julia = "1"
@@ -25,6 +24,7 @@ IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "Cassette", "DiffEqDiffTools", "IterativeSolvers", "Random", "SafeTestsets"]
+test = ["Test", "Cassette", "DiffEqDiffTools", "IterativeSolvers", "Random", "SafeTestsets", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,15 +6,12 @@ version = "0.4.0"
 [deps]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
-Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 DiffEqDiffTools = "01453d9d-ee7c-5054-8395-0335cb756afa"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 VertexSafeGraphs = "19fa3120-7c27-5ec5-8db8-b0b0aa330d6f"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
@@ -22,10 +19,12 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 julia = "1"
 
 [extras]
+Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 DiffEqDiffTools = "01453d9d-ee7c-5054-8395-0335cb756afa"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DiffEqDiffTools", "IterativeSolvers", "Random"]
+test = ["Test", "Cassette", "DiffEqDiffTools", "IterativeSolvers", "Random", "SafeTestsets"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,6 @@ julia = "1"
 
 [extras]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
-DiffEqDiffTools = "01453d9d-ee7c-5054-8395-0335cb756afa"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -27,4 +26,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "Cassette", "DiffEqDiffTools", "IterativeSolvers", "Random", "SafeTestsets", "Zygote"]
+test = ["Test", "Cassette", "IterativeSolvers", "Random", "SafeTestsets", "Zygote"]

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Currently these methods are not competitive against `numauto`, but as Zygote.jl 
 optimized these will likely be the fastest.
 
 ```julia
+using Zygote # Required
+
 numback_hesvec!(du,f,x,v,
                      cache1 = similar(v),
                      cache2 = similar(v))
@@ -267,8 +269,8 @@ in the operator, simply mutate the vector `u`: `J.u .= ...`.
 
 ### Automated Sparsity Detection
 
-Optionally, if you load Cassette.jl, automated
-sparsity detection is provided by the `sparsity!` function whose syntax is:
+Automated sparsity detection is provided by the `sparsity!` function. This requires
+`using Cassette` for Requires. The syntax is:
 
 ```julia
 `sparsity!(f, Y, X, args...; sparsity=Sparsity(length(X), length(Y)), verbose=true)`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - julia_version: 1
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:

--- a/src/SparseDiffTools.jl
+++ b/src/SparseDiffTools.jl
@@ -1,16 +1,20 @@
 module SparseDiffTools
 
-using SparseArrays, LinearAlgebra, BandedMatrices, BlockBandedMatrices,
-      LightGraphs, VertexSafeGraphs, DiffEqDiffTools, ForwardDiff, Zygote,
-      SparseArrays
-using BlockBandedMatrices:blocksize,nblocks
+using BandedMatrices
+using BlockBandedMatrices
+using DiffEqDiffTools
+using ForwardDiff
+using LightGraphs
+using Requires
+using VertexSafeGraphs
+using Zygote
+
+using LinearAlgebra
+using SparseArrays
+
+using BlockBandedMatrices: blocksize, nblocks
 using ForwardDiff: Dual, jacobian, partials, DEFAULT_CHUNK_THRESHOLD
 
-using Requires
-using Cassette
-import Cassette: tag, untag, Tagged, metadata, hasmetadata, istagged, canrecurse
-import Cassette: tagged_new_tuple, ContextTagged, BindingMeta, DisableHooks, nametype
-import Core: SSAValue
 
 export  contract_color,
         greedy_d1,
@@ -29,8 +33,7 @@ export  contract_color,
         auto_hesvecgrad,auto_hesvecgrad!,
         numback_hesvec,numback_hesvec!,
         autoback_hesvec,autoback_hesvec!,
-        JacVec,HesVec,HesVecGrad,
-        Sparsity, sparsity!, hsparsity
+        JacVec,HesVec,HesVecGrad
 
 
 include("coloring/high_level.jl")
@@ -41,8 +44,17 @@ include("coloring/greedy_star2_coloring.jl")
 include("coloring/matrix2graph.jl")
 include("differentiation/compute_jacobian_ad.jl")
 include("differentiation/jaches_products.jl")
+
 function __init__()
     @require Cassette="7057c7e9-c182-5462-911a-8362d720325c" begin
+        using .Cassette
+        using .Cassette: tag, untag, Tagged, metadata, hasmetadata, istagged, canrecurse
+        using .Cassette: tagged_new_tuple, ContextTagged, BindingMeta, DisableHooks, nametype
+
+        using Core: SSAValue
+
+        export Sparsity, hsparsity, sparsity!
+
         include("program_sparsity/program_sparsity.jl")
         include("program_sparsity/sparsity_tracker.jl")
         include("program_sparsity/path.jl")

--- a/src/SparseDiffTools.jl
+++ b/src/SparseDiffTools.jl
@@ -63,6 +63,12 @@ function __init__()
         include("program_sparsity/linearity.jl")
         include("program_sparsity/hessian.jl")
         include("program_sparsity/blas.jl")
+
+        @require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" begin
+            using .SpecialFunctions
+
+            include("program_sparsity/linearity_special.jl")
+        end
     end
 end
 

--- a/src/SparseDiffTools.jl
+++ b/src/SparseDiffTools.jl
@@ -7,7 +7,6 @@ using ForwardDiff
 using LightGraphs
 using Requires
 using VertexSafeGraphs
-using Zygote
 
 using LinearAlgebra
 using SparseArrays
@@ -31,8 +30,6 @@ export  contract_color,
         autonum_hesvec,autonum_hesvec!,
         num_hesvecgrad,num_hesvecgrad!,
         auto_hesvecgrad,auto_hesvecgrad!,
-        numback_hesvec,numback_hesvec!,
-        autoback_hesvec,autoback_hesvec!,
         JacVec,HesVec,HesVecGrad
 
 
@@ -69,6 +66,12 @@ function __init__()
 
             include("program_sparsity/linearity_special.jl")
         end
+    end
+
+    @require Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f" begin
+        export numback_hesvec, numback_hesvec!, autoback_hesvec, autoback_hesvec!
+
+        include("differentiation/jaches_products_zygote.jl")
     end
 end
 

--- a/src/differentiation/jaches_products.jl
+++ b/src/differentiation/jaches_products.jl
@@ -92,34 +92,6 @@ function numauto_hesvec(f,x,v)
     (gxp - gxm)/(2ϵ)
 end
 
-function numback_hesvec!(du,f,x,v,
-                     cache1 = similar(v),
-                     cache2 = similar(v))
-    g = let f=f
-        g = (dx,x) -> dx .= first(Zygote.gradient(f,x))
-    end
-    T = eltype(x)
-    # Should it be min? max? mean?
-    ϵ = sqrt(eps(real(T))) * max(one(real(T)), abs(norm(x)))
-    @. x += ϵ*v
-    g(cache1,x)
-    @. x -= 2ϵ*v
-    g(cache2,x)
-    @. du = (cache1 - cache2)/(2ϵ)
-end
-
-function numback_hesvec(f,x,v)
-    g = (x) -> first(Zygote.gradient(f,x))
-    T = eltype(x)
-    # Should it be min? max? mean?
-    ϵ = sqrt(eps(real(T))) * max(one(real(T)), abs(norm(x)))
-    x += ϵ*v
-    gxp = g(x)
-    x -= 2ϵ*v
-    gxm = g(x)
-    (gxp - gxm)/(2ϵ)
-end
-
 function autonum_hesvec!(du,f,x,v,
                      cache1 = similar(v),
                      cache2 = ForwardDiff.Dual{DeivVecTag}.(x, v),
@@ -134,22 +106,6 @@ end
 function autonum_hesvec(f,x,v)
     g = (x) -> DiffEqDiffTools.finite_difference_gradient(f,x)
     partials.(g(Dual{DeivVecTag}.(x, v)), 1)
-end
-
-function autoback_hesvec!(du,f,x,v,
-                     cache2 = ForwardDiff.Dual{Nothing}.(x, v),
-                     cache3 = ForwardDiff.Dual{Nothing}.(x, v))
-    g = let f=f
-        g = (dx,x) -> dx .= first(Zygote.gradient(f,x))
-    end
-    cache2 .= Dual{Nothing}.(x, v)
-    g(cache3,cache2)
-    du .= partials.(cache3, 1)
-end
-
-function autoback_hesvec(f,x,v)
-    g = (x) -> first(Zygote.gradient(f,x))
-    ForwardDiff.partials.(g(ForwardDiff.Dual{Nothing}.(x, v)), 1)
 end
 
 function num_hesvecgrad!(du,g,x,v,

--- a/src/differentiation/jaches_products_zygote.jl
+++ b/src/differentiation/jaches_products_zygote.jl
@@ -1,0 +1,40 @@
+function numback_hesvec!(du, f, x, v, cache1 = similar(v), cache2 = similar(v))
+    g = let f=f
+        (dx, x) -> dx .= first(Zygote.gradient(f,x))
+    end
+    T = eltype(x)
+    # Should it be min? max? mean?
+    ϵ = sqrt(eps(real(T))) * max(one(real(T)), abs(norm(x)))
+    @. x += ϵ*v
+    g(cache1,x)
+    @. x -= 2ϵ*v
+    g(cache2,x)
+    @. du = (cache1 - cache2)/(2ϵ)
+end
+
+function numback_hesvec(f, x, v)
+    g = x -> first(Zygote.gradient(f,x))
+    T = eltype(x)
+    # Should it be min? max? mean?
+    ϵ = sqrt(eps(real(T))) * max(one(real(T)), abs(norm(x)))
+    x += ϵ*v
+    gxp = g(x)
+    x -= 2ϵ*v
+    gxm = g(x)
+    (gxp - gxm)/(2ϵ)
+end
+
+function autoback_hesvec!(du, f, x, v, cache2 = ForwardDiff.Dual{Nothing}.(x, v),
+                          cache3 = ForwardDiff.Dual{Nothing}.(x, v))
+    g = let f=f
+        (dx, x) -> dx .= first(Zygote.gradient(f,x))
+    end
+    cache2 .= Dual{Nothing}.(x, v)
+    g(cache3,cache2)
+    du .= partials.(cache3, 1)
+end
+
+function autoback_hesvec(f, x, v)
+    g = x -> first(Zygote.gradient(f,x))
+    ForwardDiff.partials.(g(ForwardDiff.Dual{Nothing}.(x, v)), 1)
+end

--- a/src/program_sparsity/blas.jl
+++ b/src/program_sparsity/blas.jl
@@ -1,6 +1,3 @@
-using LinearAlgebra
-import LinearAlgebra.BLAS
-
 # generic implementations
 
 macro reroute(f, g)
@@ -19,7 +16,7 @@ macro reroute(f, g)
     end
 end
 
-@reroute BLAS.dot dot(Any, Any)
-@reroute BLAS.axpy! axpy!(Any,
-                          AbstractArray,
-                          AbstractArray)
+@reroute LinearAlgebra.BLAS.dot LinearAlgebra.dot(Any, Any)
+@reroute LinearAlgebra.BLAS.axpy! LinearAlgebra.axpy!(Any,
+                                                      AbstractArray,
+                                                      AbstractArray)

--- a/src/program_sparsity/hessian.jl
+++ b/src/program_sparsity/hessian.jl
@@ -1,8 +1,3 @@
-using Cassette
-import Cassette: tag, untag, Tagged, metadata, hasmetadata, istagged, canrecurse
-import Core: SSAValue
-using SparseArrays
-
 # Tags:
 Cassette.@context HessianSparsityContext
 

--- a/src/program_sparsity/linearity.jl
+++ b/src/program_sparsity/linearity.jl
@@ -4,12 +4,11 @@ const monadic_linear = [deg2rad, +, rad2deg, transpose, -, conj]
 
 const monadic_nonlinear = [asind, log1p, acsch, acos, asec, acosh, acsc, cscd, log, tand, log10, csch, asinh, abs2, cosh, sin, cos, atan, cospi, cbrt, acosd, acoth, inv, acotd, asecd, exp, acot, sqrt, sind, sinpi, asech, log2, tan, exp10, sech, coth, asin, cotd, cosd, sinh, abs, csc, tanh, secd, atand, sec, acscd, cot, exp2, expm1, atanh]
 
-diadic_of_linearity(::Val{(true, true, true)}) = [+, rem2pi, -, >, isless, <, isequal, max, min, convert]
-diadic_of_linearity(::Val{(true, true, false)}) = [*]
-diadic_of_linearity(::Val{(true, false, false)}) = [ / ]
-diadic_of_linearity(::Val{(false, true, false)}) = [ \ ]
-diadic_of_linearity(::Val{(false, false, false)}) = [hypot, atan, mod, rem, ^]
-diadic_of_linearity(::Val) = []
+const diadic_linear_true_true_true = [+, rem2pi, -, >, isless, <, isequal, max, min, convert]
+const diadic_linear_true_true_false = [*]
+const diadic_linear_true_false_false = [ / ]
+const diadic_linear_false_true_false = [ \ ]
+const diadic_linear_false_false_false = [hypot, atan, mod, rem, ^]
 
 haslinearity(f, nargs) = false
 
@@ -23,69 +22,57 @@ for f in constant_funcs
 end
 
 # linearity of a single input function is either
-# Val{true}() or Val{false}()
+# Val(true) or Val(false}
 #
 for f in monadic_linear
     @eval begin
         haslinearity(::typeof($f), ::Val{1}) = true
-        linearity(::typeof($f), ::Val{1}) = Val{true}()
+        linearity(::typeof($f), ::Val{1}) = Val(true)
     end
 end
-# linearity of a 2-arg function is:
-# Val{(linear11, linear22, linear12)}()
-#
-# linearIJ refers to the zeroness of d^2/dxIxJ
+
 for f in monadic_nonlinear
     @eval begin
         haslinearity(::typeof($f), ::Val{1}) = true
-        linearity(::typeof($f), ::Val{1}) = Val{false}()
+        linearity(::typeof($f), ::Val{1}) = Val(false)
     end
 end
 
-for linearity_mask = 0:2^3-1
-    lin = Val{map(x->x!=0, (linearity_mask & 4,
-                            linearity_mask & 2,
-                            linearity_mask & 1))}()
-
-    for f in diadic_of_linearity(lin)
-        @eval begin
-            haslinearity(::typeof($f), ::Val{2}) = true
-            linearity(::typeof($f), ::Val{2}) = $lin
-        end
+# linearity of a 2-arg function is:
+# Val((linear11, linear22, linear12))
+#
+# linearIJ refers to the zeroness of d^2/dxIxJ
+for f in diadic_linear_true_true_true
+    @eval begin
+        haslinearity(::typeof($f), ::Val{2}) = true
+        linearity(::typeof($f), ::Val{2}) = Val((true, true, true))
     end
 end
 
-
-@require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" begin
-    using .SpecialFunctions
-
-    const monadic_nonlinear_special = [airyai, airyaiprime, airybi, airybiprime, besselj0, besselj1, bessely0, bessely1, dawson, digamma, erf, erfc, erfcinv, erfi, erfinv, erfcx, gamma, invdigamma, lgamma, trigamma]
-
-    #diadic_of_linearity_special(::(Val{(true, false, true)}) = [besselk, hankelh2, bessely, besselj, besseli, polygamma, hankelh1]
-    diadic_of_linearity_special(::Val{(false, false, false)}) = [lbeta, beta]
-    diadic_of_linearity_special(::Val) = []
-
-    # linearity of a 2-arg function is:
-    # Val{(linear11, linear22, linear12)}()
-    #
-    # linearIJ refers to the zeroness of d^2/dxIxJ
-    for f in monadic_nonlinear_special
-        eval(quote
-             haslinearity(::typeof($f), ::Val{1}) = true
-             linearity(::typeof($f), ::Val{1}) = Val{false}()
-             end)
+for f in diadic_linear_true_true_false
+    @eval begin
+        haslinearity(::typeof($f), ::Val{2}) = true
+        linearity(::typeof($f), ::Val{2}) = Val((true, true, false))
     end
+end
 
-    for linearity_mask = 0:2^3-1
-        lin = Val{map(x->x!=0, (linearity_mask & 4,
-                                linearity_mask & 2,
-                                linearity_mask & 1))}()
+for f in diadic_linear_true_false_false
+    @eval begin
+        haslinearity(::typeof($f), ::Val{2}) = true
+        linearity(::typeof($f), ::Val{2}) = Val((true, false, false))
+    end
+end
 
-        for f in diadic_of_linearity_special(lin)
-            eval(quote
-                 haslinearity(::typeof($f), ::Val{2}) = true
-                 linearity(::typeof($f), ::Val{2}) = $lin
-                 end)
-        end
+for f in diadic_linear_false_true_false
+    @eval begin
+        haslinearity(::typeof($f), ::Val{2}) = true
+        linearity(::typeof($f), ::Val{2}) = Val((false, true, false))
+    end
+end
+
+for f in diadic_linear_false_false_false
+    @eval begin
+        haslinearity(::typeof($f), ::Val{2}) = true
+        linearity(::typeof($f), ::Val{2}) = Val((false, false, false))
     end
 end

--- a/src/program_sparsity/linearity.jl
+++ b/src/program_sparsity/linearity.jl
@@ -1,18 +1,14 @@
-using SpecialFunctions
-import Base.Broadcast
-
 const constant_funcs = []
 
 const monadic_linear = [deg2rad, +, rad2deg, transpose, -, conj]
 
-const monadic_nonlinear = [asind, log1p, acsch, erfc, digamma, acos, asec, acosh, airybiprime, acsc, cscd, log, tand, log10, csch, asinh, airyai, abs2, gamma, lgamma, erfcx, bessely0, cosh, sin, cos, atan, cospi, cbrt, acosd, bessely1, acoth, erfcinv, erf, dawson, inv, acotd, airyaiprime, erfinv, trigamma, asecd, besselj1, exp, acot, sqrt, sind, sinpi, asech, log2, tan, invdigamma, airybi, exp10, sech, erfi, coth, asin, cotd, cosd, sinh, abs, besselj0, csc, tanh, secd, atand, sec, acscd, cot, exp2, expm1, atanh]
+const monadic_nonlinear = [asind, log1p, acsch, acos, asec, acosh, acsc, cscd, log, tand, log10, csch, asinh, abs2, cosh, sin, cos, atan, cospi, cbrt, acosd, acoth, inv, acotd, asecd, exp, acot, sqrt, sind, sinpi, asech, log2, tan, exp10, sech, coth, asin, cotd, cosd, sinh, abs, csc, tanh, secd, atand, sec, acscd, cot, exp2, expm1, atanh]
 
 diadic_of_linearity(::Val{(true, true, true)}) = [+, rem2pi, -, >, isless, <, isequal, max, min, convert]
 diadic_of_linearity(::Val{(true, true, false)}) = [*]
-#diadic_of_linearit(::(Val{(true, false, true)}) = [besselk, hankelh2, bessely, besselj, besseli, polygamma, hankelh1]
-diadic_of_linearity(::Val{(true, false, false)}) = [/]
-diadic_of_linearity(::Val{(false, true, false)}) = [\]
-diadic_of_linearity(::Val{(false, false, false)}) = [hypot, atan, mod, rem, lbeta, ^, beta]
+diadic_of_linearity(::Val{(true, false, false)}) = [ / ]
+diadic_of_linearity(::Val{(false, true, false)}) = [ \ ]
+diadic_of_linearity(::Val{(false, false, false)}) = [hypot, atan, mod, rem, ^]
 diadic_of_linearity(::Val) = []
 
 haslinearity(f, nargs) = false
@@ -55,6 +51,41 @@ for linearity_mask = 0:2^3-1
         @eval begin
             haslinearity(::typeof($f), ::Val{2}) = true
             linearity(::typeof($f), ::Val{2}) = $lin
+        end
+    end
+end
+
+
+@require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" begin
+    using .SpecialFunctions
+
+    const monadic_nonlinear_special = [airyai, airyaiprime, airybi, airybiprime, besselj0, besselj1, bessely0, bessely1, dawson, digamma, erf, erfc, erfcinv, erfi, erfinv, erfcx, gamma, invdigamma, lgamma, trigamma]
+
+    #diadic_of_linearity_special(::(Val{(true, false, true)}) = [besselk, hankelh2, bessely, besselj, besseli, polygamma, hankelh1]
+    diadic_of_linearity_special(::Val{(false, false, false)}) = [lbeta, beta]
+    diadic_of_linearity_special(::Val) = []
+
+    # linearity of a 2-arg function is:
+    # Val{(linear11, linear22, linear12)}()
+    #
+    # linearIJ refers to the zeroness of d^2/dxIxJ
+    for f in monadic_nonlinear_special
+        eval(quote
+             haslinearity(::typeof($f), ::Val{1}) = true
+             linearity(::typeof($f), ::Val{1}) = Val{false}()
+             end)
+    end
+
+    for linearity_mask = 0:2^3-1
+        lin = Val{map(x->x!=0, (linearity_mask & 4,
+                                linearity_mask & 2,
+                                linearity_mask & 1))}()
+
+        for f in diadic_of_linearity_special(lin)
+            eval(quote
+                 haslinearity(::typeof($f), ::Val{2}) = true
+                 linearity(::typeof($f), ::Val{2}) = $lin
+                 end)
         end
     end
 end

--- a/src/program_sparsity/linearity_special.jl
+++ b/src/program_sparsity/linearity_special.jl
@@ -1,0 +1,29 @@
+const monadic_nonlinear_special = [airyai, airyaiprime, airybi, airybiprime, besselj0, besselj1, bessely0, bessely1, dawson, digamma, erf, erfc, erfcinv, erfi, erfinv, erfcx, gamma, invdigamma, lgamma, trigamma]
+
+const diadic_linear_false_false_false_special = [lbeta, beta]
+# const diadic_linear_true_false_true_special = [besselk, hankelh2, bessely, besselj, besseli, polygamma, hankelh1]
+
+for f in monadic_nonlinear_special
+    @eval begin
+        haslinearity(::typeof($f), ::Val{1}) = true
+        linearity(::typeof($f), ::Val{1}) = Val(false)
+    end
+end
+
+# linearity of a 2-arg function is:
+# Val((linear11, linear22, linear12))
+#
+# linearIJ refers to the zeroness of d^2/dxIxJ
+for f in diadic_linear_false_false_false_special
+    @eval begin
+        haslinearity(::typeof($f), ::Val{2}) = true
+        linearity(::typeof($f), ::Val{2}) = Val((false,false,false))
+    end
+end
+
+# for f in diadic_linear_true_false_true_special
+#     @eval begin
+#         haslinearity(::typeof($f), ::Val{2}) = true
+#         linearity(::typeof($f), ::Val{2}) = Val((true,false,true))
+#     end
+# end

--- a/test/program_sparsity/common.jl
+++ b/test/program_sparsity/common.jl
@@ -1,11 +1,12 @@
 ### Rules
-using Cassette
-using SparseArrays
-import Cassette: tag, untag, Tagged, metadata, hasmetadata, istagged
-using SparseDiffTools
-import SparseDiffTools: Path, BranchesPass, SparsityContext, Fixed,
-                        Input, Output, ProvinanceSet, Tainted, istainted,
-                        alldone, reset!, HessianSparsityContext
+using Cassette, SparseDiffTools
+using SparseArrays, Test
+
+using Cassette: tag, untag, Tagged, metadata, hasmetadata, istagged
+using SparseDiffTools: Path, BranchesPass, SparsityContext, Fixed,
+    Input, Output, ProvinanceSet, Tainted, istainted,
+    alldone, reset!, HessianSparsityContext
+using SparseDiffTools: TermCombination
 
 function tester(f, Y, X, args...; sparsity=Sparsity(length(Y), length(X)))
 

--- a/test/program_sparsity/hessian.jl
+++ b/test/program_sparsity/hessian.jl
@@ -1,6 +1,3 @@
-import SparseDiffTools: TermCombination
-using Test
-
 Term(i...) = TermCombination(Set([Dict(j=>1 for j in i)]))
 
 @test htesttag(x->x, [1,2]) == Input()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 using SafeTestsets
 
-@safetestset "Exact coloring via contraction" begin include("test_contraction.jl") end
-@safetestset "Greedy distance-1 coloring" begin include("test_greedy_d1.jl") end
-@safetestset "Greedy star coloring" begin include("test_greedy_star.jl") end
-@safetestset "Matrix to graph conversion" begin include("test_matrix2graph.jl") end
-@safetestset "AD using color vector" begin include("test_ad.jl") end
-@safetestset "Integration test" begin include("test_integration.jl") end
-@safetestset "Special matrices" begin include("test_specialmatrices.jl") end
-@safetestset "Jac Vecs and Hes Vecs" begin include("test_jaches_products.jl") end
-@safetestset "Program sparsity computation" begin include("program_sparsity/testall.jl") end
+@time @safetestset "Exact coloring via contraction" begin include("test_contraction.jl") end
+@time @safetestset "Greedy distance-1 coloring" begin include("test_greedy_d1.jl") end
+@time @safetestset "Greedy star coloring" begin include("test_greedy_star.jl") end
+@time @safetestset "Matrix to graph conversion" begin include("test_matrix2graph.jl") end
+@time @safetestset "AD using color vector" begin include("test_ad.jl") end
+@time @safetestset "Integration test" begin include("test_integration.jl") end
+@time @safetestset "Special matrices" begin include("test_specialmatrices.jl") end
+@time @safetestset "Jac Vecs and Hes Vecs" begin include("test_jaches_products.jl") end
+@time @safetestset "Program sparsity computation" begin include("program_sparsity/testall.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,11 @@
-using SparseDiffTools
-using Test
+using SafeTestsets
 
-
-@testset "Exact coloring via contraction" begin include("test_contraction.jl") end
-@testset "Greedy distance-1 coloring" begin include("test_greedy_d1.jl") end
-@testset "Greedy star coloring" begin include("test_greedy_star.jl") end
-@testset "Matrix to graph conversion" begin include("test_matrix2graph.jl") end
-@testset "AD using color vector" begin include("test_ad.jl") end
-@testset "Integration test" begin include("test_integration.jl") end
-@testset "Special matrices" begin include("test_specialmatrices.jl") end
-@testset "Jac Vecs and Hes Vecs" begin include("test_jaches_products.jl") end
-@testset "Program sparsity computation" begin include("program_sparsity/testall.jl") end
-
+@safetestset "Exact coloring via contraction" begin include("test_contraction.jl") end
+@safetestset "Greedy distance-1 coloring" begin include("test_greedy_d1.jl") end
+@safetestset "Greedy star coloring" begin include("test_greedy_star.jl") end
+@safetestset "Matrix to graph conversion" begin include("test_matrix2graph.jl") end
+@safetestset "AD using color vector" begin include("test_ad.jl") end
+@safetestset "Integration test" begin include("test_integration.jl") end
+@safetestset "Special matrices" begin include("test_specialmatrices.jl") end
+@safetestset "Jac Vecs and Hes Vecs" begin include("test_jaches_products.jl") end
+@safetestset "Program sparsity computation" begin include("program_sparsity/testall.jl") end

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -1,5 +1,6 @@
-using SparseDiffTools, SparseArrays, Test
+using SparseDiffTools
 using ForwardDiff: Dual, jacobian
+using SparseArrays, Test
 
 fcalls = 0
 function f(dx,x)

--- a/test/test_contraction.jl
+++ b/test/test_contraction.jl
@@ -1,7 +1,9 @@
 using SparseDiffTools
 using VertexSafeGraphs
 using LightGraphs
+
 using Random
+Random.seed!(123)
 
 test_graphs = Array{VSafeGraph, 1}(undef, 0)
 

--- a/test/test_greedy_d1.jl
+++ b/test/test_greedy_d1.jl
@@ -1,7 +1,10 @@
 using SparseDiffTools
 using VertexSafeGraphs
 using LightGraphs
+using Test
+
 using Random
+Random.seed!(123)
 
 test_graphs = Array{VSafeGraph, 1}(undef, 0)
 

--- a/test/test_greedy_star.jl
+++ b/test/test_greedy_star.jl
@@ -1,7 +1,8 @@
 using SparseDiffTools
 using LightGraphs
-using Random
+using Test
 
+using Random
 Random.seed!(123)
 
 #= Test data =#

--- a/test/test_integration.jl
+++ b/test/test_integration.jl
@@ -1,7 +1,8 @@
-using SparseDiffTools, SparseArrays
-using LinearAlgebra
-using DiffEqDiffTools
-using Test
+using SparseDiffTools
+using DiffEqDiffTools: finite_difference_jacobian, finite_difference_jacobian!
+using Cassette
+
+using LinearAlgebra, SparseArrays, Test
 
 fcalls = 0
 function f(dx,x)
@@ -31,20 +32,20 @@ colors = matrix_colors(true_jac)
 
 #Jacobian computed without coloring vector
 fcalls = 0
-J = DiffEqDiffTools.finite_difference_jacobian(f, rand(30))
+J = finite_difference_jacobian(f, rand(30))
 @test J ≈ second_derivative_stencil(30)
 @test fcalls == 31
 
 #Jacobian computed with coloring vectors
 fcalls = 0
 _J = similar(true_jac)
-DiffEqDiffTools.finite_difference_jacobian!(_J, f, rand(30), color = colors)
+finite_difference_jacobian!(_J, f, rand(30), color = colors)
 @test fcalls == 4
 @test _J ≈ J
 
 fcalls = 0
 _J = similar(true_jac)
 _denseJ = collect(_J)
-DiffEqDiffTools.finite_difference_jacobian!(_denseJ, f, rand(30), color = colors, sparsity=_J)
+finite_difference_jacobian!(_denseJ, f, rand(30), color = colors, sparsity=_J)
 @test fcalls == 4
 @test _denseJ ≈ J

--- a/test/test_jaches_products.jl
+++ b/test/test_jaches_products.jl
@@ -1,5 +1,8 @@
-using ForwardDiff, SparseDiffTools, LinearAlgebra, DiffEqDiffTools,
-      IterativeSolvers, Test
+using SparseDiffTools, ForwardDiff, DiffEqDiffTools, Zygote, IterativeSolvers
+using LinearAlgebra, Test
+
+using Random
+Random.seed!(123)
 
 const A = rand(300,300)
 f(du,u) = mul!(du,A,u)


### PR DESCRIPTION
This PR removes the dependencies on Cassette and SpecialFunctions. I'm currently running a test on Win32 (https://ci.appveyor.com/project/devmotion/delaydiffeq-jl-ungfr/build/job/femutot54m17paay) to check if by removing the dependency on Cassette we can get rid of the [compilation time issues of DelayDiffEq](https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/125).