### PR TITLE
Added acyclic coloring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.6.0"
 [deps]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqDiffTools = "01453d9d-ee7c-5054-8395-0335cb756afa"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"

--- a/src/coloring/acyclic_coloring.jl
+++ b/src/coloring/acyclic_coloring.jl
@@ -1,0 +1,93 @@
+using LightGraphs
+
+"""
+        color_graph(g::LightGraphs.AbstractGraphs, :: AcyclicColoring)
+
+Returns a coloring vector following the acyclic coloring rules (1) the coloring 
+corresponds to a distance-1 coloring, and (2) vertices in every cycle of the 
+graph are assigned at least three distinct colors. This variant of coloring is 
+called acyclic since every subgraph induced by vertices assigned any two colors
+is a collection of trees—and hence is acyclic.
+"""
+function color_graph(g::LightGraphs.AbstractGraphs, ::AcyclicColoring)
+    
+    color = zeros(Int, nv(g))
+    forbiddenColors = zeros(Int, nv(g))
+
+    for v in vertices(g)
+        #enforces the first condition of acyclic coloring
+        for w in outneighbors(g, v)
+            forbiddenColors[color[w]] = v
+        #enforces the second condition of acyclic coloring
+        for w in outneighbors(g, v)
+            if color[w] != 0 #colored neighbor
+                for x in outneighbors(w)
+                    if color[x] != 0 #colored x
+                        if forbiddenColors[color[x]] != v
+                            prevent_cycle(v, w, x)
+                        end
+                    end
+                end
+            end
+        end
+
+        color[v] = min_index(forbiddenColors, v)
+
+        #grow star for every edge connecting colored vertices v and w
+        for w in outneighbors(g, v)
+            if color[w] != 0
+                growStar(v, w)
+            end
+        end
+
+        #merge the newly formed stars into existing trees if possible
+        for w in outneighbors(g, v)
+            if color[w] != 0
+                for x in outneighbors(g, w)
+                    if color[x] != 0 && x != v
+                        if color[x] == color[v]
+                            mergeTrees(v, w, x)
+                        end
+                    end
+                end
+            end
+        end 
+    end
+end
+
+"""
+        prevent_cycle()
+
+"""
+function prevent_cycle(v::Integer,
+                       w::Integer, 
+                       x::Integer, 
+                       forbiddenColors::AbstractVector{<:Integer},
+                       firstVisitToTree)
+    e = Find(w, x)
+    p, q = firstVisitToTree[e]
+    if p != v
+        firstVisitToTree[e] = (v, w)
+    else if q != w
+        forbiddenColors[color[x]] = v
+    end
+end
+
+"""
+        min_index(forbiddenColors::AbstractVector{<:Integer}, v::Integer)
+
+Returns min{i > 0 such that forbiddenColors[i] != v}
+"""            
+function min_index(forbiddenColors, v)
+    for i = 1:length(forbiddenColors)
+        if forbiddenColors[i] != v
+            return i
+        end
+    end
+end
+
+function growStar(v:: Integer, w::Integer)
+end
+
+function mergeTrees(v:: Integer, w::Integer, x::Integer)
+end

--- a/src/coloring/acyclic_coloring.jl
+++ b/src/coloring/acyclic_coloring.jl
@@ -1,4 +1,5 @@
 using LightGraphs
+using DataStructures
 
 """
         color_graph(g::LightGraphs.AbstractGraphs, :: AcyclicColoring)
@@ -14,17 +15,25 @@ function color_graph(g::LightGraphs.AbstractGraphs, ::AcyclicColoring)
     color = zeros(Int, nv(g))
     forbiddenColors = zeros(Int, nv(g))
 
+    set = DisjointSets{LightGraphs.Edge}([])
+
+    firstVisitToTree = Array{Tuple{Int, Int}, 1}(undef, ne(g))
+    firstNeighbor = Array{Tuple{Int, Int}, 1}(undef, nv(g))
+
     for v in vertices(g)
         #enforces the first condition of acyclic coloring
         for w in outneighbors(g, v)
-            forbiddenColors[color[w]] = v
+            if color[w] != 0
+                forbiddenColors[color[w]] = v
+            end
+        end
         #enforces the second condition of acyclic coloring
         for w in outneighbors(g, v)
             if color[w] != 0 #colored neighbor
-                for x in outneighbors(w)
+                for x in outneighbors(g, w)
                     if color[x] != 0 #colored x
                         if forbiddenColors[color[x]] != v
-                            prevent_cycle(v, w, x)
+                            prevent_cycle(v, w, x, g, color, forbiddenColors, firstVisitToTree, set)
                         end
                     end
                 end
@@ -36,7 +45,7 @@ function color_graph(g::LightGraphs.AbstractGraphs, ::AcyclicColoring)
         #grow star for every edge connecting colored vertices v and w
         for w in outneighbors(g, v)
             if color[w] != 0
-                growStar(v, w)
+                grow_star(v, w, g, firstNeighbor, set)
             end
         end
 
@@ -46,13 +55,15 @@ function color_graph(g::LightGraphs.AbstractGraphs, ::AcyclicColoring)
                 for x in outneighbors(g, w)
                     if color[x] != 0 && x != v
                         if color[x] == color[v]
-                            mergeTrees(v, w, x)
+                            mergeTrees(v, w, x, g, set)
                         end
                     end
                 end
             end
         end 
     end
+
+    return color
 end
 
 """
@@ -61,13 +72,18 @@ end
 """
 function prevent_cycle(v::Integer,
                        w::Integer, 
-                       x::Integer, 
+                       x::Integer,
+                       g,
+                       color, 
                        forbiddenColors::AbstractVector{<:Integer},
-                       firstVisitToTree)
-    e = Find(w, x)
-    p, q = firstVisitToTree[e]
+                       firstVisitToTree,
+                       set)
+    
+    edge = find_edge(g, w, x)
+    e = find_root(set, edge)
+    p, q = firstVisitToTree[edge_index(g, e)]
     if p != v
-        firstVisitToTree[e] = (v, w)
+        firstVisitToTree[edge_index(g, e)] = (v, w)
     else if q != w
         forbiddenColors[color[x]] = v
     end
@@ -86,8 +102,54 @@ function min_index(forbiddenColors, v)
     end
 end
 
-function growStar(v:: Integer, w::Integer)
+function grow_star(v::Integer,
+                  w::Integer,
+                  g,
+                  firstNeighbor,
+                  set)
+    edge = find_edge(g, v, w)
+    push!(set, edge)
+    p, q = firstNeighbor[color[w]]
+    if p != v
+        firstNeighbor[color[w]] = (v, w)
+    else
+        edge1 = find_edge(g, v, w)
+        edge2 = find_edge(g, p, q)
+        e1 = find_root(set, edge1)
+        e2 = find_root(set, edge2)
+        union!(set, e1, e2)
+    end
 end
 
-function mergeTrees(v:: Integer, w::Integer, x::Integer)
+function mergeTrees(v::Integer,
+                    w::Integer, 
+                    x::Integer,
+                    g,
+                    set)
+    edge1 = find_edge(g, v, w)
+    edge2 = find_edge(g, w, x)
+    e1 = find_root(set, edge1)
+    e2 = find_root(set, edge2)
+    if (e1 != e2)
+        union!(set, e1, e2)
+    end
+end
+
+function find_edge(g, v, w)
+    for e in edges(g)
+        if (src(e) == v && dst(e) == w)
+            return e
+        end
+    end
+    throw(error("$v and $w are not connected in graph g"))
+end
+
+function edge_index(g, e)
+    edge_list = collect(edges(g))
+    for i in 1:length(edge_list)
+        if edge_list[i] == e
+            return i
+        end
+    end
+    return -1
 end

--- a/src/coloring/high_level.jl
+++ b/src/coloring/high_level.jl
@@ -4,6 +4,7 @@ struct BacktrackingColor <: ColoringAlgorithm end
 struct ContractionColor <: ColoringAlgorithm end
 struct GreedyStar1Color <: ColoringAlgorithm end
 struct GreedyStar2Color <: ColoringAlgorithm end
+struct AcyclicColoring <: ColoringAlgorithm end
 
 """
     matrix_colors(A,alg::ColoringAlgorithm = GreedyD1Color())


### PR DESCRIPTION
Allows user to color graph using acyclic coloring algorithm. 
The main difference between acyclic coloring and ordinary distance-1 coloring is that in the case of acyclic coloring, on top of the regular distance-1 coloring condition, there is an added condition that all the cycles in the graph have atleast 3 colors present. 

Example to illustrate the difference:
![a6d1589c-4600-4d7e-9a4c-958ef9995943](https://user-images.githubusercontent.com/17577971/62588161-5b932380-b8e2-11e9-993d-2e3addac48bd.jpeg)


TODO: Add tests and clean the code.