### PR TITLE
Fix issue of inconsistent size

### DIFF
--- a/src/differentiation/compute_jacobian_ad.jl
+++ b/src/differentiation/compute_jacobian_ad.jl
@@ -120,7 +120,8 @@ function forwarddiff_color_jacobian(f,x::AbstractArray{<:Number},jac_cache::Forw
             for j in 1:chunksize
                 col_index = (i-1)*chunksize + j
                 (col_index > ncols) && return J
-                J = J + mapreduce(i -> i==col_index ? partials.(vec(fx), j) : zeros(nrows), hcat, 1:ncols)
+                Ji = mapreduce(i -> i==col_index ? partials.(vec(fx), j) : zeros(nrows), hcat, 1:ncols)
+                J = J + (size(Ji)!=size(J) ? reshape(Ji,size(J)) : Ji) #branch when size(dx) == (1,) => size(Ji) == (1,) while size(J) == (1,1)
             end
         end
     end

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -219,3 +219,9 @@ J = forwarddiff_color_jacobian(oopf,x)
 J = zero(J)
 forwarddiff_color_jacobian!(J,iipf,x,dx=similar(x))
 @test J ≈ Matrix(I,4,4)
+
+#1x1 SVector test
+x = SVector{1}([1.])
+f(x) = x
+J = forwarddiff_color_jacobian(f,x)
+@test J ≈ SMatrix{1,1}([1.])


### PR DESCRIPTION
This issue leads to failure in callback tests for svector like `@test test_callback_svector(Rosenbrock23())` in `alg_event_tests.jl`.